### PR TITLE
動的ページもサイトマップに含める

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,7 +3,7 @@ import { ARTICLE_CATEGORIES, getDatabase } from '@lib/notion';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_URL;
+  const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL;
   const lastModified = new Date();
 
   const staticPaths = ARTICLE_CATEGORIES.map( category => {
@@ -37,7 +37,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         return p.properties.Slug?.type == 'rich_text'
           ?
             {
-              url: p.properties.Slug.rich_text[0].plain_text,
+              url: `${baseUrl}/blog/articles/${p.properties.Slug.rich_text[0].plain_text}`,
               lastModified
             }
           : null

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,47 @@
+import { MetadataRoute } from 'next';
+import { ARTICLE_CATEGORIES, getDatabase } from '@lib/notion';
+import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const baseUrl = process.env.NEXT_PUBLIC_URL;
+  const lastModified = new Date();
+
+  const staticPaths = ARTICLE_CATEGORIES.map( category => {
+    return {
+      url: `${baseUrl}/blog/categories/${category.name}`,
+      lastModified
+    }
+  })
+
+  const database = await getDatabase()
+
+  const articlePaths = database
+      .filter(page => {
+        // TODO: type check
+        const p = page as PageObjectResponse
+        return p.properties.Published?.type == 'checkbox'
+          ? p.properties.Published.checkbox // bool
+          : false
+      })
+      .filter(page => {
+        // TODO: type check
+        const p = page as PageObjectResponse
+        return p.properties.Slug?.type == 'rich_text'
+          ? p.properties.Slug?.rich_text[0]?.plain_text.length > 0// bool
+          : false
+
+      })
+      .map(page => {
+        // TODO: type check
+        const p = page as PageObjectResponse
+        return p.properties.Slug?.type == 'rich_text'
+          ?
+            {
+              url: p.properties.Slug.rich_text[0].plain_text,
+              lastModified
+            }
+          : null
+      })
+
+  return [...staticPaths, ...articlePaths]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "dev": "next dev -p 3002",
     "build": "next build",
-    "postbuild": "next-sitemap --config sitemap.config.js",
     "start": "next start",
     "lint": "next lint --fix",
     "predeploy": "yarn build && vercel",

--- a/sitemap.config.js
+++ b/sitemap.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  siteUrl: 'https://panda-engineer.blog',
-  generateRobotsTxt: true,
-  sitemapSize: 7000,
-  exclude: ['/top']
-};


### PR DESCRIPTION
articles ページがサイトマップに含まれてなかったので含めた

また、もともと3rd party のnpmモジュールを使って生成していたが、next.js 標準で提供している機能で十分なので、実装方法をそちらに変更