### PR TITLE
[fix] 各ラベルに表示される記事数が指定した数より少なくなるバグを修正

### DIFF
--- a/app/blog/categories/[category]/page.jsx
+++ b/app/blog/categories/[category]/page.jsx
@@ -26,10 +26,7 @@ export default async function Page(props) {
     labels.flatMap(async (lbl) => {
       let pages = await pagesIntoURI(lbl.articles, articleItemLimit)
       pages = pages
-        .filter(page => {
-          const slug = page?.properties?.Slug?.rich_text[0]?.plain_text
-          return !!slug
-        })
+        .slice(0, articleItemLimit)
         .map(page => {
           return {
             uri: `/blog/articles/${page.properties.Slug.rich_text[0].plain_text}`,

--- a/app/blog/categories/[category]/page.jsx
+++ b/app/blog/categories/[category]/page.jsx
@@ -2,8 +2,9 @@ import { builder } from "@builder.io/sdk";
 import { RenderBuilderContent } from "@components/builder";
 
 import {
-  listLabelsFromCategory, pagesIntoURI, ARTICLE_CATEGORIES
+  listLabelsFromCategory, getPage, ARTICLE_CATEGORIES
 } from '@lib/notion';
+import * as validator from '@lib/validator'
 
 // Builder Public API Key set in .env file
 builder.init(process.env.NEXT_PUBLIC_BUILDER_API_KEY);
@@ -24,8 +25,12 @@ export default async function Page(props) {
   const articleItemLimit = 3
   const labelWithPages = await Promise.all(
     labels.flatMap(async (lbl) => {
-      let pages = await pagesIntoURI(lbl.articles, articleItemLimit)
-      pages = pages
+      const pageResults = await Promise.all(
+        lbl.articles
+          .map(page => getPage(page))
+      )
+      const pages = pageResults
+        .filterForPublish()
         .slice(0, articleItemLimit)
         .map(page => {
           return {

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -126,15 +126,6 @@ export const listLabelsFromCategory = cache(async (category) => {
   )
 });
 
-// args: array of pageID
-export const pagesIntoURI = cache(async (pages, limit) => {
-  const pageResults = await Promise.all(
-    pages
-      .map(page => getPage(page))
-  )
-  return pageResults.filterForPublish().slice(0, limit)
-})
-
 export const getBlocks = cache(async (blockID) => {
   const blockId = blockID.replaceAll('-', '');
 

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -130,10 +130,9 @@ export const listLabelsFromCategory = cache(async (category) => {
 export const pagesIntoURI = cache(async (pages, limit) => {
   const pageResults = await Promise.all(
     pages
-      .slice(0, limit)
       .map(page => getPage(page))
   )
-  return pageResults
+  return pageResults.filterForPublish().slice(0, limit)
 })
 
 export const getBlocks = cache(async (blockID) => {

--- a/lib/validator.ts
+++ b/lib/validator.ts
@@ -1,0 +1,8 @@
+interface Array<T> {
+  filterForPublish: () => {}
+}
+Array.prototype.filterForPublish = function () {
+  return this
+    .filter(page => page?.properties?.Published?.checkbox)
+    .filter(page => !!(page?.properties?.Slug?.rich_text[0]?.plain_text))
+}


### PR DESCRIPTION
# バグ事象

カテゴリ画面にて、各ラベルごとに3つのアイテムを表示するよう指定したのに、それより表示が少ない場合がある。

# バグの原因

最初に3つに絞ったあと、さらに公開するかどうかの条件で絞り込みを行っていた。

# 共通化

公開するかどうかの条件は、サイト内の随所で使えそうなので共通の関数に分割して定義した


