### PR TITLE
Databaseの全ページを取得する

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,7 +13,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   })
 
-  const database = await getDatabase()
+  const database = await getDatabase(true)
 
   const articlePaths = database
       .filter(page => {

--- a/components/notion/builder/renderer.jsx
+++ b/components/notion/builder/renderer.jsx
@@ -105,7 +105,7 @@ export function Block({block}) {
     case 'divider':
       return <hr key={id} />;
     case 'quote':
-      return <blockquote key={id}>{value.rich_text[0].plain_text}</blockquote>;
+      return <blockquote key={id}>{value.rich_text[0]?.plain_text}</blockquote>;
     case 'code':
       const notionLang = value.language
       return (

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -1,4 +1,4 @@
-import { Client } from '@notionhq/client';
+import { Client, iteratePaginatedAPI } from '@notionhq/client';
 import { PageObjectResponse } from '@notionhq/client/build/src/api-endpoints';
 import { cache } from 'react';
 
@@ -33,10 +33,13 @@ const notion = new Client({
 });
 
 export const getDatabase = cache(async () => {
-  const response = await notion.databases.query({
+  const allResponse = []
+  for await (const response of iteratePaginatedAPI(notion.databases.query, {
     database_id: databaseId,
-  });
-  return response.results;
+  })) {
+    allResponse.push(response.results)
+  }
+  return allResponse;
 });
 
 export const getTagLibraryDatabase = cache(async () => {

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -32,15 +32,21 @@ const notion = new Client({
   auth: process.env.NOTION_TOKEN,
 });
 
-export const getDatabase = cache(async () => {
-  const allResponse = []
-  for await (const response of iteratePaginatedAPI(notion.databases.query, {
+export const getDatabase = cache(async (build) => {
+  const allPages = []
+  for await (const pages of iteratePaginatedAPI(notion.databases.query, {
     database_id: databaseId,
   })) {
-    allResponse.push(response.results)
+    allPages.push(pages)
+    // avoid API limit when build
+    build && await sleep(100)
   }
-  return allResponse;
+  return allPages
 });
+
+const sleep = (milliseconds) => {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
 
 export const getTagLibraryDatabase = cache(async () => {
   const response = await notion.databases.query({

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,8 @@ const nextConfig = withBuilderDevTools({
         permanent: false
       }
     ];
-  }
+  },
+  staticPageGenerationTimeout: 120
 });
 
 module.exports = nextConfig;


### PR DESCRIPTION
notion api は取得できる最大のページ数に制限がある。
すべて取得するためにはページネーションでイテレートする必要がある。
それに対応することで、すべてのページをビルド時に取得させるようにする。
